### PR TITLE
Remove hardcoded 'amd64' from Dockerfile to support multi-arch builds.

### DIFF
--- a/images/cluster-capacity/Dockerfile
+++ b/images/cluster-capacity/Dockerfile
@@ -1,10 +1,13 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/kubernetes-incubator/cluster-capacity
 COPY . .
-RUN make build
+RUN make build; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/kubernetes-incubator/cluster-capacity/_output/local/bin/linux/$(go env GOARCH)/hypercc /tmp/build/hypercc
+
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/kubernetes-incubator/cluster-capacity/_output/local/bin/linux/amd64/hypercc /usr/bin/
+COPY --from=builder /tmp/build/hypercc /usr/bin/
 RUN ln -sf /usr/bin/hypercc /usr/bin/cluster-capacity
 RUN ln -sf /usr/bin/hypercc /usr/bin/genpod
 CMD ["/usr/bin/cluster-capacity", "--help"]

--- a/images/cluster-capacity/Dockerfile.rhel7
+++ b/images/cluster-capacity/Dockerfile.rhel7
@@ -1,10 +1,12 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/kubernetes-incubator/cluster-capacity
 COPY . .
-RUN make build
+RUN make build; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/kubernetes-incubator/cluster-capacity/_output/local/bin/linux/$(go env GOARCH)/hypercc /tmp/build/hypercc
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/kubernetes-incubator/cluster-capacity/_output/local/bin/linux/amd64/hypercc /usr/bin/
+COPY --from=builder /tmp/build/hypercc /usr/bin/
 RUN ln -sf /usr/bin/hypercc /usr/bin/cluster-capacity
 RUN ln -sf /usr/bin/hypercc /usr/bin/genpod
 CMD ["/usr/bin/cluster-capacity", "--help"]


### PR DESCRIPTION
Remove hardcoded 'amd64' from Dockerfile to support multi-arch builds.