### PR TITLE
Simplify dockerfile and call go build directly

### DIFF
--- a/images/cluster-capacity/Dockerfile
+++ b/images/cluster-capacity/Dockerfile
@@ -1,13 +1,10 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/kubernetes-incubator/cluster-capacity
 COPY . .
-RUN make build; \
-    mkdir -p /tmp/build; \
-    cp /go/src/github.com/kubernetes-incubator/cluster-capacity/_output/local/bin/linux/$(go env GOARCH)/hypercc /tmp/build/hypercc
-
+RUN go build -o hypercc ./cmd/hypercc
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /tmp/build/hypercc /usr/bin/
+COPY --from=builder /go/src/github.com/kubernetes-incubator/cluster-capacity/hypercc /usr/bin/
 RUN ln -sf /usr/bin/hypercc /usr/bin/cluster-capacity
 RUN ln -sf /usr/bin/hypercc /usr/bin/genpod
 CMD ["/usr/bin/cluster-capacity", "--help"]

--- a/images/cluster-capacity/Dockerfile.rhel7
+++ b/images/cluster-capacity/Dockerfile.rhel7
@@ -1,12 +1,10 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/kubernetes-incubator/cluster-capacity
 COPY . .
-RUN make build; \
-    mkdir -p /tmp/build; \
-    cp /go/src/github.com/kubernetes-incubator/cluster-capacity/_output/local/bin/linux/$(go env GOARCH)/hypercc /tmp/build/hypercc
+RUN go build -o hypercc ./cmd/hypercc
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /tmp/build/hypercc /usr/bin/
+COPY --from=builder /go/src/github.com/kubernetes-incubator/cluster-capacity/hypercc /usr/bin/
 RUN ln -sf /usr/bin/hypercc /usr/bin/cluster-capacity
 RUN ln -sf /usr/bin/hypercc /usr/bin/genpod
 CMD ["/usr/bin/cluster-capacity", "--help"]


### PR DESCRIPTION
Dockerfile calls 'make build' target which is unnecessary. We can call go build directly and get rid of all the scripts that makes the building process and debugging complicated.
