### PR TITLE
bump Dockerfile.ocp to 4.21

### DIFF
--- a/images/cluster-capacity/Dockerfile.ocp
+++ b/images/cluster-capacity/Dockerfile.ocp
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 WORKDIR /go/src/sigs.k8s.io/cluster-capacity
 COPY . .
 RUN GO111MODULE=auto go build -o hypercc ./cmd/hypercc
 
-FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 COPY --from=builder /go/src/sigs.k8s.io/cluster-capacity/hypercc /usr/bin/
 RUN ln -sf /usr/bin/hypercc /usr/bin/cluster-capacity
 RUN ln -sf /usr/bin/hypercc /usr/bin/genpod


### PR DESCRIPTION
logs in ART sync-ci-images job.
```
2025-09-26 00:05:23,408 artcommonlib INFO [containers/openshift-enterprise-cluster-capacity] 
Desired parents: ['registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21', 'registry.ci.openshift.org/ocp/4.21:base-rhel9'] (64d948803aa2d49cdc9e4201c979836f)
Desired build_root (in .ci-operator.yaml): {'namespace': 'openshift', 'name': 'release', 'tag': 'rhel-9-release-golang-1.24-openshift-4.21'}

Source parents: ['registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20', 'registry.ci.openshift.org/ocp/4.20:base-rhel9'] (20f70e0e9419132dc63b14761b4e5b02)
Source build_root (in .ci-operator.yaml): {'name': 'release', 'namespace': 'openshift', 'tag': 'rhel-9-release-golang-1.24-openshift-4.20'}

Fork build_root (in .ci-operator.yaml): None

Upstream dockerfile does not match desired state in git@github.com:openshift/cluster-capacity.git/blob/main/images/cluster-capacity/Dockerfile.ocp
```